### PR TITLE
fix: corrected mapping of label and route of starting pages (Fixes: #7)

### DIFF
--- a/app/src/main/java/net/greenapple/arrestwt/ui/page/SettingsPage.kt
+++ b/app/src/main/java/net/greenapple/arrestwt/ui/page/SettingsPage.kt
@@ -53,8 +53,8 @@ fun SettingsPage(
 
   /* === Page Values */
   val startingPageLabels        = remember { NavRoute.bottomNavRoutes.map { it.label } }
-  val startingPageLabelsByRoute = remember { NavRoute.bottomNavRoutes.associate { it.label to it.route } }
-  val startingPageRoutesByLabel = remember { NavRoute.bottomNavRoutes.associate { it.route to it.label } }
+  val startingPageLabelsByRoute = remember { NavRoute.bottomNavRoutes.associate { it.route to it.label } }
+  val startingPageRoutesByLabel = remember { NavRoute.bottomNavRoutes.associate { it.label to it.route } }
   val selectedStartingPage      by settingsViewModel.selectedStartingPageFlow.collectAsState()
 
   val startingPageSafePage      = remember(selectedStartingPage) {


### PR DESCRIPTION
Fixes #7

- Switches mappings for startingPageLabelsByRoute and startingPageRoutesByLabel in the settings page.